### PR TITLE
Arreglo de resolucion en personaje del robot en los sprites

### DIFF
--- a/Assets/ArtPipelineFolder/Sprites/sprite_sheet_attack2.png.meta
+++ b/Assets/ArtPipelineFolder/Sprites/sprite_sheet_attack2.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 8192
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 0

--- a/Assets/ArtPipelineFolder/Sprites/sprite_sheet_backward2.png.meta
+++ b/Assets/ArtPipelineFolder/Sprites/sprite_sheet_backward2.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 8192
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 0

--- a/Assets/ArtPipelineFolder/Sprites/sprite_sheet_damage2.png.meta
+++ b/Assets/ArtPipelineFolder/Sprites/sprite_sheet_damage2.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 8192
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 0

--- a/Assets/ArtPipelineFolder/Sprites/sprite_sheet_forward2.png.meta
+++ b/Assets/ArtPipelineFolder/Sprites/sprite_sheet_forward2.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 8192
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 0

--- a/Assets/ArtPipelineFolder/Sprites/sprite_sheet_idle2.png.meta
+++ b/Assets/ArtPipelineFolder/Sprites/sprite_sheet_idle2.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 8192
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 0

--- a/Assets/ArtPipelineFolder/Sprites/sprite_sheet_power2.png.meta
+++ b/Assets/ArtPipelineFolder/Sprites/sprite_sheet_power2.png.meta
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 8192
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 0


### PR DESCRIPTION
Se hizo un cambio al tamaño máximo de los sprites para arreglar la resolución de estos